### PR TITLE
Clean up tests and add another failing test case

### DIFF
--- a/test/integration/reservation_flow_test.rb
+++ b/test/integration/reservation_flow_test.rb
@@ -10,10 +10,10 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-10"
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-21", end_date: "2019-01-30"
 
-    # we should be able to make a reservation in the empty space between existing reservations
+    # try to make a reservation in the empty space between existing reservations
     post reservations_path, params: { reservation: { start_date: "2019-01-11", end_date: "2019-01-20", vehicle_category_id: vehicle_category.id } }
-    follow_redirect!
-    assert_response :success
+
+    # the new reservation should be saved
     assert_equal 3, Reservation.count
   end
 
@@ -25,10 +25,10 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
     # create a reservation that lasts the entire month
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-31"
 
-    # by having only one car we should not be able to make new reservations
+    # by having only one car we should not be able to make new reservations during that month
     post reservations_path, params: { reservation: { start_date: "2019-01-11", end_date: "2019-01-20", vehicle_category_id: vehicle_category.id } }
-    follow_redirect!
-    assert_response :success
+
+    # the new reservation should not be saved
     assert_equal 1, Reservation.count
   end
 end

--- a/test/integration/reservation_flow_test.rb
+++ b/test/integration/reservation_flow_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 class ReservationFlowTest < ActionDispatch::IntegrationTest
   test "should create a reservation if a car is available to be rented" do
-    FactoryBot.create :vehicle # this also creates the VehicleModel and VehicleCategory
-    vehicle_category = VehicleCategory.first
+    vehicle_category = FactoryBot.create :vehicle_category
+    vehicle_model = FactoryBot.create :vehicle_model, vehicle_category: vehicle_category
+    FactoryBot.create :vehicle, vehicle_model: vehicle_model
 
     # lets create 2 reservations that allow for another reservation in between them
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-10"
@@ -17,8 +18,9 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
   end
 
   test "cannot create a reservation when no vehicles are available" do
-    FactoryBot.create :vehicle # this also creates the VehicleModel and VehicleCategory
-    vehicle_category = VehicleCategory.first
+    vehicle_category = FactoryBot.create :vehicle_category
+    vehicle_model = FactoryBot.create :vehicle_model, vehicle_category: vehicle_category
+    FactoryBot.create :vehicle, vehicle_model: vehicle_model
 
     # lets create a reservation that lasts the entire month
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-31"

--- a/test/integration/reservation_flow_test.rb
+++ b/test/integration/reservation_flow_test.rb
@@ -6,7 +6,7 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
     vehicle_model = FactoryBot.create :vehicle_model, vehicle_category: vehicle_category
     FactoryBot.create :vehicle, vehicle_model: vehicle_model
 
-    # lets create 2 reservations that allow for another reservation in between them
+    # create 2 reservations that allow for another reservation in between them
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-10"
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-21", end_date: "2019-01-30"
 
@@ -22,7 +22,7 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
     vehicle_model = FactoryBot.create :vehicle_model, vehicle_category: vehicle_category
     FactoryBot.create :vehicle, vehicle_model: vehicle_model
 
-    # lets create a reservation that lasts the entire month
+    # create a reservation that lasts the entire month
     FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-01", end_date: "2019-01-31"
 
     # by having only one car we should not be able to make new reservations

--- a/test/integration/reservation_flow_test.rb
+++ b/test/integration/reservation_flow_test.rb
@@ -31,4 +31,19 @@ class ReservationFlowTest < ActionDispatch::IntegrationTest
     # the new reservation should not be saved
     assert_equal 1, Reservation.count
   end
+
+  test "cannot create a reservation when no vehicles are available during the entire time range" do
+    vehicle_category = FactoryBot.create :vehicle_category
+    vehicle_model = FactoryBot.create :vehicle_model, vehicle_category: vehicle_category
+    FactoryBot.create :vehicle, vehicle_model: vehicle_model
+
+    # create a short reservation in the middle of the month
+    FactoryBot.create :reservation, vehicle_category: vehicle_category, start_date: "2019-01-15", end_date: "2019-01-16"
+
+    # by having only one car we should not be able to make new reservations including those days
+    post reservations_path, params: { reservation: { start_date: "2019-01-11", end_date: "2019-01-20", vehicle_category_id: vehicle_category.id } }
+
+    # the new reservation should not be saved
+    assert_equal 1, Reservation.count
+  end
 end


### PR DESCRIPTION
This PR makes a few changes to tests:
 - Tests now create a `vehicle_category` explicitly. I think this makes the relations between the objects a little clearer and would make it easier to test with multiple vehicles if we wanted to.
 - Got rid of the `follow_redirect!` and `assert_response :success`. The controller only redirects in the successful save case, and the error messages for these assertions are more cryptic than the ones on the number of reservations.
 - Added another failing scenario covering an existing partially-overlapping reservation.